### PR TITLE
Improve the performance of FilterRule#valid_access?

### DIFF
--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -19,10 +19,13 @@ class FilterRule < Setting
     remote_ip_addr = IPAddr.new(remote_ip)
     return true if remote_ip_addr.loopback?
 
-    allowed_ip_addrs = self.allowed_ip_list.collect { |ip| IPAddr.new(ip) rescue nil }.reject(&:nil?)
-    return true if allowed_ip_addrs.empty?
-
-    allowed_ip_addrs.select { |allowed_ip_addr| allowed_ip_addr.include?(remote_ip_addr) }.any?
+    self.allowed_ip_list.any? do |ip|
+      begin
+        IPAddr.new(ip).include?(remote_ip_addr)
+      rescue IPAddr::Error
+        nil
+      end
+    end
   end
 
   def allowed_ips=(ips)


### PR DESCRIPTION
This patch improves the performance of `FilterRule#valid_access?` by reducing the number of expensive `IPAddr.new` calls.

Currently, `valid_access?` calls `IPAddr.new` as many times as the number of allowed IP addresses. This improved code stops calling `IPAddr.new` when an allowed IP address matches `remote_ip`.