### PR TITLE
Log when access is denied

### DIFF
--- a/lib/application_controller_patch.rb
+++ b/lib/application_controller_patch.rb
@@ -20,6 +20,7 @@ module RedmineIPFilter
             }
             format.any { head 403 }
           end
+          logger.info "redmine_ip_filter: rejected access from #{request.remote_ip}"
           return false
         end
       end


### PR DESCRIPTION
This change adds a feature to record log when access from an unpermitted IP address is rejected. This small change makes it easier for admins to read production.log.

Before:
```
  Rendered plugins/redmine_ip_filter/app/views/filter_rules/403.html.erb (10.9ms)
Filter chain halted as :check_remote_ip rendered or redirected
Completed 403 Forbidden in 20ms (Views: 11.9ms | ActiveRecord: 2.7ms)
```

After:
```
  Rendered plugins/redmine_ip_filter/app/views/filter_rules/403.html.erb (10.9ms)
redmine_ip_filter: rejected access from 198.51.100.1
Filter chain halted as :check_remote_ip rendered or redirected
Completed 403 Forbidden in 20ms (Views: 11.9ms | ActiveRecord: 2.7ms)
```