### PR TITLE
Add always_allowed_ip_list using yml configuration

### DIFF
--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -18,7 +18,8 @@ class FilterRule < Setting
 
     remote_ip_addr = IPAddr.new(remote_ip)
 
-    self.allowed_ip_list.any? do |ip|
+    always_allowed_ip_list = IPFilterConfig['always_allowed_ip_list'] || []
+    (self.allowed_ip_list | always_allowed_ip_list).any? do |ip|
       begin
         IPAddr.new(ip).include?(remote_ip_addr)
       rescue IPAddr::Error

--- a/config/ip_filter_config.yml.example
+++ b/config/ip_filter_config.yml.example
@@ -1,0 +1,4 @@
+production:
+  always_allowed_ip_list:
+    - 127.0.0.1
+    - 10.0.0.0/8

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,6 @@
 require_dependency 'application_controller_patch'
 require_dependency 'redmine_ip_filter_hook_listener'
+require_dependency 'ip_filter_config'
 Redmine::Plugin.register :redmine_ip_filter do
   name 'Redmine Ip Filter'
   author 'Far End Technologies Corporation'

--- a/lib/ip_filter_config.rb
+++ b/lib/ip_filter_config.rb
@@ -1,0 +1,19 @@
+class IPFilterConfig
+  @@instance = nil
+  @@config = {}
+
+  def self.[](key)
+    @@instance ||= new
+    @@config[key]
+  end
+
+  def initialize
+    file = "#{Rails.root}/plugins/redmine_ip_filter/config/ip_filter_config.yml"
+    if File.file?(file)
+      config = YAML.load_file(file)
+      if config.is_a?(Hash) && config.has_key?(Rails.env)
+        @@config = config[Rails.env]
+      end
+    end
+  end
+end

--- a/test/config/ip_filter_config.yml
+++ b/test/config/ip_filter_config.yml
@@ -1,0 +1,4 @@
+test:
+  always_allowed_ip_list:
+    - 127.0.0.1
+    - 10.0.0.0/8

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -34,6 +34,13 @@ class FilterRuleTest < ActiveSupport::TestCase
     assert @filter_rule.valid_access?('22.33.44.55')
   end
 
+  def test_valid_access_returns_true_remote_ip_includes_always_allowed_ip
+    #IPFilterConfig.class_variable_set :@@config, {'always_allowed_ip_list' => ['33.44.55.66']}
+    IPFilterConfig.stubs(:'[]').with('always_allowed_ip_list').returns(['33.44.55.66', '44.55.66.77'])
+    assert @filter_rule.valid_access?('33.44.55.66')
+    assert @filter_rule.valid_access?('44.55.66.77')
+  end
+
   def test_valid_access_returns_false
     assert !@filter_rule.valid_access?('33.44.55.66')
   end

--- a/test/unit/lib/ip_filter_config_test.rb
+++ b/test/unit/lib/ip_filter_config_test.rb
@@ -1,0 +1,31 @@
+require File.expand_path('../../../test_helper', __FILE__)
+
+class IPFilterConfigTest < ActiveSupport::TestCase
+
+  def setup
+    IPFilterConfig.class_variable_set :@@instance, nil
+    IPFilterConfig.class_variable_set :@@config, {}
+    @config_file = "#{Rails.root}/plugins/redmine_ip_filter/config/ip_filter_config.yml"
+    @yml_data = YAML.load_file(File.dirname(__FILE__) + '/../../config/ip_filter_config.yml')
+  end
+
+  def test_always_allowed_ip_list
+    File.stubs(:file?).with(@config_file).returns(true)
+    YAML.stubs(:load_file).with(@config_file).returns(@yml_data)
+
+    assert_equal ['127.0.0.1', '10.0.0.0/8'], IPFilterConfig['always_allowed_ip_list']
+  end
+
+  def test_always_allowed_ip_list_empty_when_configuration_blank
+    File.stubs(:file?).with(@config_file).returns(true)
+    YAML.stubs(:load_file).with(@config_file).returns('')
+
+    assert_nil IPFilterConfig['always_allowed_ip_list']
+  end
+
+  def test_always_allowed_ip_list_empty_when_configuration_file_does_not_exist
+    File.stubs(:file?).with(@config_file).returns(false)
+
+    assert_nil IPFilterConfig['always_allowed_ip_list']
+  end
+end


### PR DESCRIPTION
Add the ability to set ip address for always allowing access from special addresses, such as issue registration through a mail server.
It is effective only when allowed ip address are set by Admin user.