### PR TITLE
Fix that the before action check_remote_ip may be disabled in development mode

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
-require_dependency 'application_controller_patch'
 require_dependency 'redmine_ip_filter_hook_listener'
+
 Redmine::Plugin.register :redmine_ip_filter do
   name 'Redmine Ip Filter'
   author 'Far End Technologies Corporation'
@@ -12,3 +12,8 @@ Redmine::Plugin.register :redmine_ip_filter do
 end
 
 Rails.application.config.action_dispatch.trusted_proxies = %W(#{ENV['RemoteIPTrustedProxy']} 127.0.0.1 ::1).reject(&:empty?).map{ |proxy| IPAddr.new(proxy) }
+
+Rails.configuration.to_prepare do
+  require_dependency 'application_controller_patch'
+  ApplicationController.send(:include, RedmineIPFilter::ApplicationControllerPatch)
+end

--- a/lib/application_controller_patch.rb
+++ b/lib/application_controller_patch.rb
@@ -26,5 +26,3 @@ module RedmineIPFilter
     end
   end
 end
-
-ApplicationController.send(:include, RedmineIPFilter::ApplicationControllerPatch) unless ApplicationController.included_modules.include? RedmineIPFilter::ApplicationControllerPatch


### PR DESCRIPTION
When a Redmine instance is running in development mode, the IP filtering feature stops working if you update the code of the plugin.

**Steps to reproduce:**
1. Configure redmine_ip_filter to reject your IP address
2. Access to the Redmine instance from an unpermitted IP address. The plugin rejects your address
3. Update `lib/application_controller_patch.rb`
4. Reload your browser. The IP filtering feature stops working and you can access the Redmine even though the IP address is not allowed