### PR TITLE
Enable frozen_string_literal

### DIFF
--- a/app/controllers/filter_rules_controller.rb
+++ b/app/controllers/filter_rules_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FilterRulesController < ApplicationController
   layout 'admin'
   self.main_menu = false

--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FilterRule < Setting
   require 'ipaddr'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Plugin's routes
 # See: http://guides.rubyonrails.org/routing.html
 resource :filter_rule, :only => [:edit, :create, :update]

--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_dependency 'redmine_ip_filter_hook_listener'
 
 Redmine::Plugin.register :redmine_ip_filter do

--- a/lib/application_controller_patch.rb
+++ b/lib/application_controller_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_dependency 'application_controller'
 
 module RedmineIPFilter

--- a/lib/redmine_ip_filter_hook_listener.rb
+++ b/lib/redmine_ip_filter_hook_listener.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RedmineIpFilterHookListener < Redmine::Hook::ViewListener
   def view_layouts_base_html_head(context)
     stylesheet_link_tag 'redmine_ip_filter', plugin: :redmine_ip_filter

--- a/test/functional/filter_rules_controller_test.rb
+++ b/test/functional/filter_rules_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../../test_helper', __FILE__)
 
 class FilterRulesControllerTest < ActionController::TestCase

--- a/test/integration/lib/application_controller_patch_test.rb
+++ b/test/integration/lib/application_controller_patch_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../../../test_helper', __FILE__)
 
 class ApplicationControllerPatchTest < Redmine::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Redmine helper
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
 ActiveRecord::FixtureSet.create_fixtures(File.dirname(__FILE__) + '/fixtures', 'filter_rules')

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../../test_helper', __FILE__)
 
 class FilterRuleTest < ActiveSupport::TestCase


### PR DESCRIPTION
In my environment, enabling `frozen_string_literal` improved the performance (requests/sec) about 4% when 100 filter rules are set.

```
ab -n 2000  -c 2 http://$IP/sandbox/login
```

**Before:**
|   | Requests per second   |
|:-:|:---------------------:|
| 1 |        84.78          |
| 2 |        86.20          |
| 3 |        83.08          |

**After:**
|   | Requests per second   |
|:-:|:---------------------:|
| 1 |        90.27          |
| 2 |        88.20          |
| 3 |        87.48          |