### PR TITLE
Add rake taks to manipulate the allowed IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,44 @@ $ cd /path/to/redmine
 $ rm -rf plugins/redmine_ip_filter
 ```
 
+## Command line tools
+
+### Add IP addresses to the allowed IP addresses
+
+```
+$ cd /path/to/redmine
+$ bin/rails redmine_ip_filter:filters:add ADDR=198.51.100.10
+ADD     198.51.100.10
+$ bin/rails redmine_ip_filter:filters:add ADDR=198.51.100.11,192.0.2.0/28
+ADD     198.51.100.11
+ADD     192.0.2.0/28
+```
+
+### Delete IP addresses from the allowed IP addresses
+
+```
+$ cd /path/to/redmine
+$ bin/rails redmine_ip_filter:filters:delete ADDR=198.51.100.11
+DELETE  198.51.100.11
+```
+
+### Show the allowed IP addresses
+
+```
+$ bin/rails redmine_ip_filter:filters:show
+198.51.100.10
+192.0.2.0/28
+```
+
+### Test if given IP addresses are allowed
+
+```
+$ bin/rails redmine_ip_filter:filters:test REMOTE_ADDR=192.0.2.15,192.0.2.16
+ALLOW   192.0.2.15
+REJECT  192.0.2.16
+```
+
+
 ## Licence
 
 This plugin is licensed under the GNU General Public License, version 2 (GPLv2)

--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -65,7 +65,7 @@ class FilterRule < Setting
         end
       end
       # validate admin_remote_ip inclusion
-      unless obj.valid_access?(obj.admin_remote_ip)
+      if obj.admin_remote_ip.present? && !obj.valid_access?(obj.admin_remote_ip)
         obj.errors.add :base, l(:error_filter_rules_have_to_include_admin_ip, :ip => obj.admin_remote_ip)
       end
     end

--- a/lib/tasks/util.rake
+++ b/lib/tasks/util.rake
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'ipaddr'
+
+namespace :redmine_ip_filter do
+  namespace :filters do
+    desc 'Show the allowed IP addresses'
+    task :show => :environment do
+      puts FilterRule.find_or_default.allowed_ips
+    end
+
+    desc 'Add IP addresses to the allowed IP addresses'
+    task :add => :environment do
+      addresses = ENV['ADDR'].to_s.split(/[,[:space:]]/)
+      if addresses.empty?
+        abort 'IP addresses to add must be specified with ADDR environment variable'
+      end
+      filter_rule = FilterRule.find_or_default
+      filter_rule.allowed_ips = (filter_rule.allowed_ips.split + addresses).join("\r\n")
+      unless filter_rule.save
+        STDERR.puts filter_rule.errors.messages[:base]
+        exit 1
+      end
+      puts addresses.map {|address| "ADD\t#{address}"}
+    end
+
+    desc 'Delete IP addresses from the allowed IP addresses'
+    task :delete => :environment do
+      addresses = ENV['ADDR'].to_s.split(/[,[:space:]]/)
+      if addresses.empty?
+        abort 'IP addresses to delete must be specified with ADDR environment variable'
+      end
+      begin
+        ipaddrs_del = addresses.map {|address| IPAddr.new(address)}				
+      rescue IPAddr::Error => e
+        STDERR.puts e.message
+        exit 1
+      end
+
+      allowed_addresses = FilterRule.find_or_default.allowed_ips.split
+      delete_addresses = []
+      allowed_addresses.each do |address|
+        if address.present? && ipaddrs_del.include?(IPAddr.new(address))
+          delete_addresses << address
+        end
+      end
+      
+      allowed_addresses -= delete_addresses
+      # Use the Setting object to skip validations
+      Setting.plugin_redmine_ip_filter = {:allowed_ips => allowed_addresses.join("\r\n")}
+      puts delete_addresses.map {|address| "DELETE\t#{address}"}
+    end
+    
+    desc 'Test if given IP addresses are allowed'
+    task :test => :environment do
+      addresses = ENV['REMOTE_ADDR'].to_s.split(/[,[:space:]]/)
+      if addresses.empty?
+        abort 'IP addresses to test must be set to REMOTE_ADDR environment variable'
+      elsif FilterRule.find_or_default.allowed_ips.blank?
+        puts 'Any IP address is allowed because "Allowed IP Addresses" is blank'
+        exit
+      end
+      addresses.each do |address|
+        status = ''
+        errmsg = ''
+        begin
+          ipaddr = IPAddr.new(address)
+          if ipaddr.ipv4? == false
+            status = 'ERROR'
+            errmsg = 'Only IPv4 is supported'
+          elsif ipaddr.prefix != 32
+            status = 'ERROR'
+            errmsg = 'REMOTE_ADDR must not be an address block'
+          else
+            status = FilterRule.valid_access?(address) ? 'ALLOW' : 'REJECT'
+          end
+        rescue IPAddr::Error => e
+          status = 'ERROR'
+          errmsg = e.message
+        end
+        print "#{status}\t#{address}"
+        print "\t(#{errmsg})" unless errmsg.empty?
+        print "\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds command line tools to add, delete, show, or test the allowed IP addresses. Server admins will be able to manipulate the allowed IP addresses without logging in to Redmine.

See the updated README.md file for how to use them.