### PR TITLE
Fix that error_filter_rules_include_others does not show an actual network address

### DIFF
--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -60,8 +60,11 @@ class FilterRule < Setting
           errors.add(:base, l(:error_filter_rules_loopback, :ip => ip)) if ipaddr.loopback?
           errors.add(:base, l(:error_filter_rules_linklocal, :ip => ip)) if ipaddr.link_local?
         end
-        if (network_address = allowed_ip_addrs.values.find{|ip| ip != ipaddr && ip.include?(ipaddr)})
-          errors.add(:base, l(:error_filter_rules_include_others, :ip => ip, :network_address => network_address))
+        allowed_ip_addrs.each do |ip_other, ipaddr_other|
+          next if ipaddr.object_id == ipaddr_other.object_id
+          if ipaddr_other.include?(ipaddr)
+            errors.add(:base, l(:error_filter_rules_include_others, :ip => ip, :network_address => ip_other))
+          end
         end
       end
       # validate admin_remote_ip inclusion

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -114,7 +114,7 @@ class FilterRuleTest < ActiveSupport::TestCase
   def test_validate_address_include_other_address
     @filter_rule.allowed_ips = "11.22.33.0/24\r11.22.33.1"
     assert !@filter_rule.valid?
-    assert_include I18n.translate(:error_filter_rules_include_others, :ip => '11.22.33.1', :network_address => '11.22.33.0'), @filter_rule.errors[:base]
+    assert_include I18n.translate(:error_filter_rules_include_others, :ip => '11.22.33.1', :network_address => '11.22.33.0/24'), @filter_rule.errors[:base]
   end
 
   def test_validate_admin_remote_ip_inclusion


### PR DESCRIPTION
Suppose that you attempt to save the following values to Allowed IP addresses:

```
198.51.100.10
198.51.100.0/24
```

Since 198.51.100.10 is included in the block 198.51.100.0/24, you will see an error message "Allowed IP addresses cannot be saved because 198.51.100.10 is in the range of 198.51.100.0.".  However, 198.51.100.0 is different from 198.51.100.0/24, the value you entered.

This pull request fixes the error message to display the exact value you entered, like ""Allowed IP addresses cannot be saved because 198.51.100.10 is in the range of 198.51.100.0/24."

![image](https://user-images.githubusercontent.com/114863/88480150-3e41e400-cf8f-11ea-905b-34fa245d6c22.png)
