### PR TITLE
Normalize allowed ips when saving

### DIFF
--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -39,7 +39,7 @@ class FilterRule < Setting
   end
 
   def allowed_ip_list
-    self.allowed_ips.to_s.split.reject(&:blank?)
+    self.allowed_ips.to_s.split
   end
 
   validate do |obj|

--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -31,7 +31,7 @@ class FilterRule < Setting
   end
 
   def allowed_ips=(ips)
-    self.value = {'allowed_ips' => ips.to_s}
+    self.value = {'allowed_ips' => ips.to_s.split.join("\n")}
   end
 
   def allowed_ips

--- a/test/functional/filter_rules_controller_test.rb
+++ b/test/functional/filter_rules_controller_test.rb
@@ -10,7 +10,7 @@ class FilterRulesControllerTest < ActionController::TestCase
   def setup
     @request.session[:user_id] = 1 # admin
     @filter_rule = FilterRule.find_or_default
-    @filter_rule.allowed_ips="11.22.33.44\r22.33.44.55"
+    @filter_rule.allowed_ips="11.22.33.44\n22.33.44.55"
     @filter_rule.save!
     ActionController::TestRequest.any_instance.stubs(:remote_ip).returns('11.22.33.44')
   end
@@ -18,7 +18,7 @@ class FilterRulesControllerTest < ActionController::TestCase
   def test_edit
     get :edit
     assert_response :success
-    assert_select 'textarea#filter_rule_allowed_ips', :text => "11.22.33.44\r22.33.44.55"
+    assert_select 'textarea#filter_rule_allowed_ips', :text => "11.22.33.44\n22.33.44.55"
   end
 
   def test_create
@@ -45,7 +45,7 @@ class FilterRulesControllerTest < ActionController::TestCase
   end
 
   def test_update
-    new_address = "11.22.33.44\r33.44.55.66"
+    new_address = "11.22.33.44\n33.44.55.66"
     assert @filter_rule.persisted?
 
     put :update, :params => { :filter_rule => { :allowed_ips => new_address } }
@@ -63,6 +63,6 @@ class FilterRulesControllerTest < ActionController::TestCase
     assert_select 'textarea#filter_rule_allowed_ips', :text => invalid_address
     assert_select 'div#errorExplanation li', :text => I18n.translate(:error_invalid_ip_addres_format_or_value, :message => "invalid address: #{invalid_address}")
     @filter_rule.reload
-    assert_equal "11.22.33.44\r22.33.44.55", @filter_rule.allowed_ips
+    assert_equal "11.22.33.44\n22.33.44.55", @filter_rule.allowed_ips
   end
 end

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -7,7 +7,7 @@ class FilterRuleTest < ActiveSupport::TestCase
   def setup
     @filter_rule = FilterRule.find_or_default
     @filter_rule.admin_remote_ip = '11.22.33.44'
-    @filter_rule.allowed_ips="11.22.33.44\r22.33.44.55"
+    @filter_rule.allowed_ips="11.22.33.44\n22.33.44.55"
     @filter_rule.save!
   end
 
@@ -59,7 +59,7 @@ class FilterRuleTest < ActiveSupport::TestCase
   end
 
   def test_allowed_ip_list
-    FilterRule.any_instance.stubs(:allowed_ips).returns("11.22.33.44\r\r22.33.44.55")
+    FilterRule.any_instance.stubs(:allowed_ips).returns("11.22.33.44\n\n22.33.44.55")
     assert_equal ['11.22.33.44', '22.33.44.55'], @filter_rule.allowed_ip_list
   end
 
@@ -67,17 +67,17 @@ class FilterRuleTest < ActiveSupport::TestCase
     org_limit = FilterRule.send(:remove_const, :ALLOWED_IP_LIMIT)
     FilterRule.const_set(:ALLOWED_IP_LIMIT, 1)
 
-    @filter_rule.allowed_ips = "11.22.33.44\r22.33.44.55"
+    @filter_rule.allowed_ips = "11.22.33.44\n22.33.44.55"
     assert !@filter_rule.valid?
     assert_include I18n.translate(:error_filter_rules_over_limit, limit: 1), @filter_rule.errors[:base]
-    @filter_rule.allowed_ips = "11.22.33.44\r22.33.44.55"
+    @filter_rule.allowed_ips = "11.22.33.44\n22.33.44.55"
 
     FilterRule.send(:remove_const, :ALLOWED_IP_LIMIT)
     FilterRule.const_set(:ALLOWED_IP_LIMIT, org_limit)
   end
 
   def test_validate_format
-    @filter_rule.allowed_ips = "11.22.33.44\r\r22.33.44.0/24\r22.33.44.Go"
+    @filter_rule.allowed_ips = "11.22.33.44\n\n22.33.44.0/24\n22.33.44.Go"
     assert !@filter_rule.valid?
     assert_include I18n.translate(:error_invalid_ip_addres_format_or_value, :message => 'invalid address: 22.33.44.Go'), @filter_rule.errors[:base]
   end
@@ -111,7 +111,7 @@ class FilterRuleTest < ActiveSupport::TestCase
   end
 
   def test_validate_address_include_other_address
-    @filter_rule.allowed_ips = "11.22.33.0/24\r11.22.33.1"
+    @filter_rule.allowed_ips = "11.22.33.0/24\n11.22.33.1"
     assert !@filter_rule.valid?
     assert_include I18n.translate(:error_filter_rules_include_others, :ip => '11.22.33.1', :network_address => '11.22.33.0/24'), @filter_rule.errors[:base]
   end


### PR DESCRIPTION
This pull request changes `FilterRule#allowed_ips=` to normalize values when saving:

* Strip leading and preceding whitespaces from each value
* Ensure that the values are saved with the format "ADDR1\nADDR2\nADDDR3\n....ADDRn"