### PR TITLE
Include HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR in the reject log

### DIFF
--- a/lib/application_controller_patch.rb
+++ b/lib/application_controller_patch.rb
@@ -22,7 +22,9 @@ module RedmineIPFilter
             }
             format.any { head 403 }
           end
-          logger.info "redmine_ip_filter: rejected access from #{request.remote_ip}"
+          logger.info "redmine_ip_filter: rejected access from #{request.remote_ip} " \
+            "(HTTP_CLIENT_IP=#{request.client_ip.inspect} " \
+            "HTTP_X_FORWARDED_FOR=#{request.x_forwarded_for.inspect})"
           return false
         end
       end


### PR DESCRIPTION
This change makes troubleshooting easier when a Redmine server is placed behind proxy servers or load balancers.


**Before:**
```
redmine_ip_filter: rejected access from 5.6.7.8
```

**After:**
```
redmine_ip_filter: rejected access from 5.6.7.8 (HTTP_CLIENT_IP=nil HTTP_X_FORWARDED_FOR="1.2.3.4, 5.6.7.8")
```