### PR TITLE
Add "Original URL" and "Date" to 403 error page

### DIFF
--- a/app/views/filter_rules/403.html.erb
+++ b/app/views/filter_rules/403.html.erb
@@ -11,6 +11,8 @@
     <p class="message"><%= @message %></p>
     <p class="info"><label>Remote Address:</label> <%= request.remote_ip %></p>
     <p class="info"><label>User Agent:</label> <%= request.headers.env['HTTP_USER_AGENT'] %></p>
+    <p class="info"><label>Original URL:</label> <%= request.original_url %></p>
+    <p class="info"><label>Date:</label> <%= Time.now %></p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
This pull request adds two data to the 403 error page, "Original URL" and "Date".

This change makes it easier for server admins to troubleshoot when they get screenshots of the page.