### PR TITLE
Fix Ruby version dependency on error message

### DIFF
--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -56,7 +56,7 @@ class FilterRule < Setting
       begin
         [ip, IPAddr.new(ip)]
       rescue IPAddr::Error => e
-        obj.errors.add(:base, l(:error_invalid_ip_addres_format_or_value, :message => "invalid address: #{ip}"))
+        obj.errors.add(:base, l(:error_invalid_ip_addres_format_or_value, :ip => ip))
         nil
       end
     end.compact.to_h

--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -56,7 +56,7 @@ class FilterRule < Setting
       begin
         [ip, IPAddr.new(ip)]
       rescue IPAddr::Error => e
-        obj.errors.add(:base, l(:error_invalid_ip_addres_format_or_value, :message => e.message))
+        obj.errors.add(:base, l(:error_invalid_ip_addres_format_or_value, :message => "invalid address: #{ip}"))
         nil
       end
     end.compact.to_h

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,7 @@ en:
 
   notice_forbidden_access_from_your_ip: Your IP address %{ip} is not allowed.
   notice_filter_rule_was_successfully_updated: Allowed IP addresses have been successfully updated.
-  error_invalid_ip_addres_format_or_value:     Invalid IP address (%{message}).
+  error_invalid_ip_addres_format_or_value:     Invalid IP address (%{ip}).
   error_filter_rules_have_to_include_admin_ip: Your current IP address must be included in allowed IP addresses (%{ip}).
   error_filter_rules_over_limit: Allowed IP addresses cannot be saved because the number of FilterRules over the limit %{limit}.
   error_filter_rules_ipv6: "Allowed IP addresses cannot be saved because %{ip} is an IPv6 address."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,7 +15,7 @@ ja:
 
   notice_forbidden_access_from_your_ip: "%{ip} からのアクセスは許可されていません。"
   notice_filter_rule_was_successfully_updated: アクセス許可IPアドレスを更新しました。
-  error_invalid_ip_addres_format_or_value:     IPアドレスとしてのフォーマットまたは値が正しくありません (%{message}) 。
+  error_invalid_ip_addres_format_or_value:     IPアドレスとしてのフォーマットまたは値が正しくありません (%{ip}) 。
   error_filter_rules_have_to_include_admin_ip: アクセス許可IPアドレスは現在接続中のIPアドレス (%{ip}) を含まなければなりません。
   error_filter_rules_over_limit: アクセス許可IPアドレスの個数が上限 %{limit} を超えるため登録できません。
   error_filter_rules_ipv6: "IPv6アドレス %{ip} は登録できません。"

--- a/test/functional/filter_rules_controller_test.rb
+++ b/test/functional/filter_rules_controller_test.rb
@@ -38,7 +38,7 @@ class FilterRulesControllerTest < ActionController::TestCase
     post :create , :params => { :filter_rule => { :allowed_ips => invalid_address } }
     assert_response :success
     assert_select 'textarea#filter_rule_allowed_ips', :text => invalid_address
-    assert_select 'div#errorExplanation li', :text => I18n.translate(:error_invalid_ip_addres_format_or_value, :message => "invalid address: #{invalid_address}")
+    assert_select 'div#errorExplanation li', :text => I18n.translate(:error_invalid_ip_addres_format_or_value, :ip => invalid_address)
 
     @filter_rule = FilterRule.find_or_default
     assert_equal '', @filter_rule.allowed_ips
@@ -72,7 +72,7 @@ class FilterRulesControllerTest < ActionController::TestCase
     put :update, :params => { :filter_rule => { :allowed_ips => invalid_address } }
     assert_response :success
     assert_select 'textarea#filter_rule_allowed_ips', :text => invalid_address
-    assert_select 'div#errorExplanation li', :text => I18n.translate(:error_invalid_ip_addres_format_or_value, :message => "invalid address: #{invalid_address}")
+    assert_select 'div#errorExplanation li', :text => I18n.translate(:error_invalid_ip_addres_format_or_value, :ip => invalid_address)
     @filter_rule.reload
     assert_equal "11.22.33.44\n22.33.44.55", @filter_rule.allowed_ips
   end

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -96,7 +96,7 @@ class FilterRuleTest < ActiveSupport::TestCase
   def test_validate_format
     @filter_rule.allowed_ips = "11.22.33.44\n\n22.33.44.0/24\n22.33.44.Go"
     assert !@filter_rule.valid?
-    assert_include I18n.translate(:error_invalid_ip_addres_format_or_value, :message => 'invalid address: 22.33.44.Go'), @filter_rule.errors[:base]
+    assert_include I18n.translate(:error_invalid_ip_addres_format_or_value, :ip => '22.33.44.Go'), @filter_rule.errors[:base]
   end
 
   def test_validate_ipv6_addr


### PR DESCRIPTION
This PR resolves the issue reported by @maeda-m in #44.
After the fix, users will get error messages (including Invalid IP Addr) independent of Ruby version differences.