### PR TITLE
Support for SVG icons in Redmine6

### DIFF
--- a/assets/images/icons.svg
+++ b/assets/images/icons.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" class="icon--sprite">
+  <defs>
+    <symbol viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round" id="icon--redmine-ip-filter">
+      <path d="M4 4h16v2.172a2 2 0 0 1 -.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48 -4.928a2 2 0 0 1 -.52 -1.345v-2.227z"/>
+    </symbol>
+  </defs>
+</svg>

--- a/assets/stylesheets/redmine_ip_filter.css
+++ b/assets/stylesheets/redmine_ip_filter.css
@@ -1,4 +1,4 @@
-#admin-menu a.redmine-ip-filter { background-image: url(../images/redmine_ip_filter.png); }
+.icon-redmine-ip-filter:not(:has(svg)) { background-image: url(../images/redmine_ip_filter.png); }
 form.edit_filter_rule .tabular.settings p {
   padding-left: 200px;
 }

--- a/config/icon_source.yml
+++ b/config/icon_source.yml
@@ -1,0 +1,2 @@
+- name: redmine-ip-filter
+  svg: filter

--- a/init.rb
+++ b/init.rb
@@ -12,6 +12,6 @@ Redmine::Plugin.register :redmine_ip_filter do
   version '1.0.0'
   url 'http://github.com/redmica/redmine_ip_filter'
   author_url 'https://hosting.redmine.jp/'
-  menu :admin_menu, :redmine_ip_filter, { controller: :filter_rules, action: :edit }, caption: :label_ip_filter, :html => { :class => 'icon icon-ip-filter' }
+  menu :admin_menu, :redmine_ip_filter, { controller: :filter_rules, action: :edit }, caption: :label_ip_filter, :html => { :class => 'icon icon-redmine-ip-filter' }, :icon => 'redmine-ip-filter', :plugin => :redmine_ip_filter
   settings :default => { 'allowed_ips' => '' }
 end


### PR DESCRIPTION
Supports SVG icons adopted in Redmine6.

## Implementation:

* SVG icons to be displayed in the Admin menu are added to Asset