### PR TITLE
Change CI environment from RedMica3.0 to RedMica3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-3.0'
+            redmine-version: 'stable-3.1'
             ruby-version: '3.3'
           - redmine-repository: 'redmica/redmica'
             redmine-version: 'master'


### PR DESCRIPTION
This pull request will change the RedMica version of the CI environment from 3.0 to 3.1.

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R18): Updated the Redmine version from 'stable-3.0' to 'stable-3.1' in the test matrix.