### PR TITLE
Fix admin-menu selection handling

### DIFF
--- a/app/controllers/filter_rules_controller.rb
+++ b/app/controllers/filter_rules_controller.rb
@@ -3,6 +3,7 @@
 class FilterRulesController < ApplicationController
   layout 'admin'
   self.main_menu = false
+  self.menu_item :redmine_ip_filter
 
   before_action :require_admin
   before_action :set_filter_rule, only: [:edit, :create, :update]

--- a/test/functional/filter_rules_controller_test.rb
+++ b/test/functional/filter_rules_controller_test.rb
@@ -15,6 +15,12 @@ class FilterRulesControllerTest < ActionController::TestCase
     ActionController::TestRequest.any_instance.stubs(:remote_ip).returns('11.22.33.44')
   end
 
+  def test_admin_menu_selected
+    get :edit
+    assert_response :success
+    assert_select '#admin-menu .redmine-ip-filter.selected', :text => I18n.translate(:label_ip_filter)
+  end
+
   def test_edit
     get :edit
     assert_response :success


### PR DESCRIPTION
This pull request fixes an issue where the IP address filter menu item was not marked as selected in the admin menu when accessing the filter settings screen.

### Changes

- Added `self.menu_item :redmine_ip_filter` to `FilterRulesController` to ensure proper menu highlighting  
- Added a functional test to verify that the correct admin menu item is selected

### Notes

- Verified that the IP address filter menu item is correctly highlighted when visiting the filter settings page  
- All tests, including the new one, pass successfully
