### PR TITLE
Improve IP filter performance by caching IPAddr objects

### DIFF
--- a/app/models/filter_rule.rb
+++ b/app/models/filter_rule.rb
@@ -4,15 +4,23 @@ class FilterRule < Setting
   require 'ipaddr'
 
   ALLOWED_IP_LIMIT = (ENV['AllowedIPLimit'] || 100).to_i
+  PLUGIN_SETTING_NAME = 'plugin_redmine_ip_filter'
 
   attr_accessor :admin_remote_ip
 
   def self.find_or_default
-    super('plugin_redmine_ip_filter')
+    super(PLUGIN_SETTING_NAME)
   end
 
   def self.valid_access?(remote_ip)
-    self.find_or_default.valid_access?(remote_ip)
+    # Use Setting[] to read from Redmine's in-memory cache without a DB query.
+    # Call find_or_default only when the setting value has changed.
+    current_setting = Setting[PLUGIN_SETTING_NAME]
+    if @cached_rule.nil? || @cached_rule_setting != current_setting
+      @cached_rule = find_or_default
+      @cached_rule_setting = current_setting
+    end
+    @cached_rule.valid_access?(remote_ip)
   end
 
   def valid_access?(remote_ip)
@@ -21,13 +29,16 @@ class FilterRule < Setting
     remote_ip_addr = IPAddr.new(remote_ip)
 
     always_allowed_ip_list = RedmineIpFilter::IpFilterConfig['always_allowed_ip_list'] || []
-    (self.allowed_ip_list | always_allowed_ip_list).any? do |ip|
-      begin
-        IPAddr.new(ip).include?(remote_ip_addr)
-      rescue IPAddr::Error
-        nil
-      end
+    sig = [self.allowed_ips.to_s, always_allowed_ip_list]
+
+    if @cached_ip_addrs_sig != sig
+      @cached_ip_addrs = (self.allowed_ip_list | always_allowed_ip_list).map { |ip|
+        begin; IPAddr.new(ip); rescue IPAddr::Error; nil; end
+      }.compact
+      @cached_ip_addrs_sig = sig
     end
+
+    @cached_ip_addrs.any? { |ip_addr| ip_addr.include?(remote_ip_addr) }
   end
 
   def allowed_ips=(ips)

--- a/lib/redmine_ip_filter/ip_filter_config.rb
+++ b/lib/redmine_ip_filter/ip_filter_config.rb
@@ -5,7 +5,8 @@ module RedmineIpFilter
 
     def self.[](key)
       @@instance ||= new
-      @@config[key]
+      # Freeze the returned value to prevent in-place mutation from corrupting the cache signature.
+      @@config[key]&.freeze
     end
 
     def initialize

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -170,4 +170,25 @@ class FilterRuleTest < ActiveSupport::TestCase
     FilterRule.expects(:find_or_default).once.returns(@filter_rule)
     2.times { FilterRule.valid_access?('11.22.33.44') }
   end
+
+  def test_class_valid_access_reloads_rule_when_setting_changes
+    # Reset the class-level cache
+    FilterRule.instance_variable_set(:@cached_rule, nil)
+    FilterRule.instance_variable_set(:@cached_rule_setting, nil)
+
+    original_setting = Setting[FilterRule::PLUGIN_SETTING_NAME]
+    begin
+      # find_or_default should be called twice: once for each distinct setting value
+      FilterRule.expects(:find_or_default).twice.returns(@filter_rule)
+      FilterRule.valid_access?('11.22.33.44')
+
+      updated_setting = original_setting.is_a?(Hash) ? original_setting.merge('cache_test' => 'changed') : {'cache_test' => 'changed'}
+      Setting[FilterRule::PLUGIN_SETTING_NAME] = updated_setting
+      FilterRule.valid_access?('11.22.33.44')
+
+      assert_equal updated_setting, FilterRule.instance_variable_get(:@cached_rule_setting)
+    ensure
+      Setting[FilterRule::PLUGIN_SETTING_NAME] = original_setting
+    end
+  end
 end

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -5,6 +5,10 @@ require File.expand_path('../../test_helper', __FILE__)
 class FilterRuleTest < ActiveSupport::TestCase
 
   def setup
+    Setting.clear_cache
+    FilterRule.instance_variable_set(:@cached_rule, nil)
+    FilterRule.instance_variable_set(:@cached_rule_setting, nil)
+
     @filter_rule = FilterRule.find_or_default
     @filter_rule.admin_remote_ip = '11.22.33.44'
     @filter_rule.allowed_ips="11.22.33.44\n22.33.44.55"
@@ -162,33 +166,26 @@ class FilterRuleTest < ActiveSupport::TestCase
   end
 
   def test_class_valid_access_caches_rule
-    # Reset the class-level cache
-    FilterRule.instance_variable_set(:@cached_rule, nil)
-    FilterRule.instance_variable_set(:@cached_rule_setting, nil)
-
     # find_or_default should be called only once when the setting has not changed
     FilterRule.expects(:find_or_default).once.returns(@filter_rule)
     2.times { FilterRule.valid_access?('11.22.33.44') }
   end
 
-  def test_class_valid_access_reloads_rule_when_setting_changes
-    # Reset the class-level cache
-    FilterRule.instance_variable_set(:@cached_rule, nil)
-    FilterRule.instance_variable_set(:@cached_rule_setting, nil)
+  def test_class_valid_access_uses_updated_allowed_ips_when_setting_changes
+    Setting[FilterRule::PLUGIN_SETTING_NAME] = {
+      'allowed_ips' => '11.22.33.44',
+      'allowed_ips_with_comments' => '11.22.33.44'
+    }
 
-    original_setting = Setting[FilterRule::PLUGIN_SETTING_NAME]
-    begin
-      # find_or_default should be called twice: once for each distinct setting value
-      FilterRule.expects(:find_or_default).twice.returns(@filter_rule)
-      FilterRule.valid_access?('11.22.33.44')
+    assert FilterRule.valid_access?('11.22.33.44')
+    assert !FilterRule.valid_access?('22.33.44.55')
 
-      updated_setting = original_setting.is_a?(Hash) ? original_setting.merge('cache_test' => 'changed') : {'cache_test' => 'changed'}
-      Setting[FilterRule::PLUGIN_SETTING_NAME] = updated_setting
-      FilterRule.valid_access?('11.22.33.44')
+    Setting[FilterRule::PLUGIN_SETTING_NAME] = {
+      'allowed_ips' => '22.33.44.55',
+      'allowed_ips_with_comments' => '22.33.44.55'
+    }
 
-      assert_equal updated_setting, FilterRule.instance_variable_get(:@cached_rule_setting)
-    ensure
-      Setting[FilterRule::PLUGIN_SETTING_NAME] = original_setting
-    end
+    assert !FilterRule.valid_access?('11.22.33.44')
+    assert FilterRule.valid_access?('22.33.44.55')
   end
 end

--- a/test/unit/filter_rule_test.rb
+++ b/test/unit/filter_rule_test.rb
@@ -139,4 +139,35 @@ class FilterRuleTest < ActiveSupport::TestCase
     assert !@filter_rule.valid?
     assert_include I18n.translate(:error_filter_rules_have_to_include_admin_ip, :ip => @filter_rule.admin_remote_ip), @filter_rule.errors[:base]
   end
+
+  def test_valid_access_caches_ip_addrs
+    # The cache is built on the first call
+    @filter_rule.valid_access?('11.22.33.44')
+    cached_addrs = @filter_rule.instance_variable_get(:@cached_ip_addrs)
+    assert_not_nil cached_addrs
+
+    # The same object is reused when allowed_ips has not changed
+    @filter_rule.valid_access?('22.33.44.55')
+    assert_same cached_addrs, @filter_rule.instance_variable_get(:@cached_ip_addrs)
+  end
+
+  def test_valid_access_rebuilds_cache_when_allowed_ips_changes
+    @filter_rule.valid_access?('11.22.33.44')
+    cached_addrs = @filter_rule.instance_variable_get(:@cached_ip_addrs)
+
+    # The cache is rebuilt when allowed_ips changes
+    @filter_rule.allowed_ips = "33.44.55.66"
+    @filter_rule.valid_access?('33.44.55.66')
+    refute_same cached_addrs, @filter_rule.instance_variable_get(:@cached_ip_addrs)
+  end
+
+  def test_class_valid_access_caches_rule
+    # Reset the class-level cache
+    FilterRule.instance_variable_set(:@cached_rule, nil)
+    FilterRule.instance_variable_set(:@cached_rule_setting, nil)
+
+    # find_or_default should be called only once when the setting has not changed
+    FilterRule.expects(:find_or_default).once.returns(@filter_rule)
+    2.times { FilterRule.valid_access?('11.22.33.44') }
+  end
 end

--- a/test/unit/lib/ip_filter_config_test.rb
+++ b/test/unit/lib/ip_filter_config_test.rb
@@ -28,4 +28,12 @@ class IpFilterConfigTest < ActiveSupport::TestCase
 
     assert_nil RedmineIpFilter::IpFilterConfig['always_allowed_ip_list']
   end
+
+  def test_always_allowed_ip_list_is_frozen
+    File.stubs(:file?).with(@config_file).returns(true)
+    YAML.stubs(:load_file).with(@config_file).returns(@yml_data)
+
+    result = RedmineIpFilter::IpFilterConfig['always_allowed_ip_list']
+    assert result.frozen?, 'returned array should be frozen to prevent cache signature corruption'
+  end
 end


### PR DESCRIPTION
Based on the concept proposed by @vividtone in #57, this PR implements caching of IPAddr objects with lightweight signature-based invalidation to improve IP filtering performance.

## Changes

- `FilterRule#valid_access?`: Cache parsed `IPAddr` objects and rebuild only when the allowed IP list changes
- `FilterRule.valid_access?`: Cache the rule object at class level using `Setting[]` as a signature, reducing DB queries per request
- `IpFilterConfig.[]`: Freeze returned values to prevent in-place mutation from corrupting cache signatures
- Add unit tests for the above caching behaviors

## Performance (measured in production environment)

| Branch | 400 IPs | 2000 IPs |
|---|---|---|
| master | 2–3ms (90ms) | 6–7ms (102ms) |
| this PR | 1–2ms (55ms) | 2ms (69ms) |

*Values in parentheses are first-request response times.*