### PR TITLE
Update RedMica test target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-4.0'
+            redmine-version: 'stable-4.1'
             ruby-version: '3.4'
           - redmine-repository: 'redmine/redmine'
             redmine-version: 'master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         database: 'postgres:14'
 
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: plugins/redmine_ip_filter
 


### PR DESCRIPTION
This PR changes the RedMica test target from stable-4.0 to stable-4.1 and updates actions.